### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Set ```inline``` to ```true``` to inline the content of the resource.
 
 Generate a HTML script element in HTML5:
 
-    stylesheets.main = Ttree.Script:External {
+    javascripts.main = Ttree.Script:External {
         uri = 'http://www.domain.com/main.js'
     }
 


### PR DESCRIPTION
technically it doesn't make a difference, but I'd recommend the readme to feature the Fusion object name "javascripts" instead of stylesheets